### PR TITLE
Add support for Info, Trace and Debug logs

### DIFF
--- a/src/Hamelin.Runtimes.GitHubActions/Hamelin.Runtimes.GitHubActions.csproj
+++ b/src/Hamelin.Runtimes.GitHubActions/Hamelin.Runtimes.GitHubActions.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/hamelin-org/Hamelin.Runtimes.GitHubActions.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsLogger.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsLogger.cs
@@ -35,9 +35,13 @@ internal class GitHubActionsLogger(
             case LogLevel.Warning:
                 commands.LogWarning(message);
                 break;
+            case LogLevel.Information:
+                commands.LogNotice(message);
+                break;
             case LogLevel.Trace:
             case LogLevel.Debug:
-            case LogLevel.Information:
+                commands.LogDebug(message);
+                break;
             case LogLevel.None:
             default:
                 // Do nothing.
@@ -45,10 +49,7 @@ internal class GitHubActionsLogger(
         }
     }
 
-    public bool IsEnabled(LogLevel logLevel)
-    {
-        return logLevel is LogLevel.Critical or LogLevel.Error or LogLevel.Warning;
-    }
+    public bool IsEnabled(LogLevel logLevel) => logLevel is not LogLevel.None;
 
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => scopeProvider?.Push(state) ?? null;
 }

--- a/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsLoggerProvider.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsLoggerProvider.cs
@@ -4,7 +4,7 @@ namespace Hamelin.Runtimes.GitHubActions.Logging;
 
 internal class GitHubActionsLoggerProvider(
     IGitHubActionsCommands commands,
-    IExternalScopeProvider? scopeProvider
+    IExternalScopeProvider? scopeProvider = null
 ) : ILoggerProvider
 {
     public ILogger CreateLogger(string categoryName) => new GitHubActionsLogger(commands, scopeProvider);


### PR DESCRIPTION
* Fixes a bug with `IExternalScopeProvider` not being registered.
* Adds support for informational and debug logs.
