### PR TITLE
Display multi-line errors correctly

### DIFF
--- a/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
@@ -79,7 +79,7 @@ public class GitHubActionsCommands : IGitHubActionsCommands
         int? endColumn = null
     )
     {
-        var args = new Dictionary<string, string?>()
+        var args = new Dictionary<string, string?>
         {
             { "title", title },
             { "file", file },
@@ -105,6 +105,8 @@ public class GitHubActionsCommands : IGitHubActionsCommands
                 argString = " " + string.Join(",", existingArgs);
             }
         }
+
+        message = StringUtils.SanitizeNewLines(message);
         Console.Out.WriteLine($"::{command}{argString}::{message}");
     }
 }

--- a/src/Hamelin.Runtimes.GitHubActions/Hamelin.Runtimes.GitHubActions.csproj
+++ b/src/Hamelin.Runtimes.GitHubActions/Hamelin.Runtimes.GitHubActions.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/hamelin-org/Hamelin.Runtimes.GitHubActions.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsConsoleFormatter.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsConsoleFormatter.cs
@@ -6,6 +6,8 @@ namespace Hamelin.Runtimes.GitHubActions.Logging;
 
 internal class GitHubActionsConsoleFormatter() : ConsoleFormatter(Constants.FormatterName)
 {
+    private const string UrlEncodedNewLine = "%0A";
+
     public override void Write<TState>(
         in LogEntry<TState> logEntry,
         IExternalScopeProvider? scopeProvider,
@@ -37,10 +39,16 @@ internal class GitHubActionsConsoleFormatter() : ConsoleFormatter(Constants.Form
         }
 
         string message = logEntry.Formatter.Invoke(logEntry.State, logEntry.Exception);
-        textWriter.WriteLine(message);
+        textWriter.Write(message);
+
         if (logEntry.Exception != null)
         {
-            textWriter.WriteLine(logEntry.Exception.ToString());
+            textWriter.Write(UrlEncodedNewLine);
+            string exceptionMessage = logEntry.Exception.ToString()
+                .Replace("\r", "")
+                .Replace("\n", UrlEncodedNewLine);
+            textWriter.Write(exceptionMessage);
         }
+        textWriter.WriteLine();
     }
 }

--- a/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsConsoleFormatter.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsConsoleFormatter.cs
@@ -6,8 +6,6 @@ namespace Hamelin.Runtimes.GitHubActions.Logging;
 
 internal class GitHubActionsConsoleFormatter() : ConsoleFormatter(Constants.FormatterName)
 {
-    private const string UrlEncodedNewLine = "%0A";
-
     public override void Write<TState>(
         in LogEntry<TState> logEntry,
         IExternalScopeProvider? scopeProvider,
@@ -39,14 +37,13 @@ internal class GitHubActionsConsoleFormatter() : ConsoleFormatter(Constants.Form
         }
 
         string message = logEntry.Formatter.Invoke(logEntry.State, logEntry.Exception);
+        message = StringUtils.SanitizeNewLines(message);
         textWriter.Write(message);
 
         if (logEntry.Exception != null)
         {
-            textWriter.Write(UrlEncodedNewLine);
-            string exceptionMessage = logEntry.Exception.ToString()
-                .Replace("\r", "")
-                .Replace("\n", UrlEncodedNewLine);
+            textWriter.Write(StringUtils.UrlEncodedNewLine);
+            string exceptionMessage = StringUtils.SanitizeNewLines(logEntry.Exception.ToString());
             textWriter.Write(exceptionMessage);
         }
         textWriter.WriteLine();

--- a/src/Hamelin.Runtimes.GitHubActions/StringUtils.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/StringUtils.cs
@@ -1,0 +1,8 @@
+namespace Hamelin.Runtimes.GitHubActions;
+
+internal static class StringUtils
+{
+    public const string UrlEncodedNewLine = "%0A";
+
+    public static string SanitizeNewLines(string input) => input.Replace("\r", "").Replace("\n", UrlEncodedNewLine);
+}

--- a/tests/Hamelin.Runtimes.GitHubActions.Tests.Unit/Logging/GitHubActionsConsoleFormatterTests.cs
+++ b/tests/Hamelin.Runtimes.GitHubActions.Tests.Unit/Logging/GitHubActionsConsoleFormatterTests.cs
@@ -66,7 +66,7 @@ public class GitHubActionsConsoleFormatterTests
 
         // Assert
         string output = _writer.ToString();
-        output.ShouldBe("::error::Test Error\nSystem.Exception: Test Exception\n");
+        output.ShouldBe("::error::Test Error%0ASystem.Exception: Test Exception\n");
     }
 
     [Fact]


### PR DESCRIPTION
GitHub Actions doesn't allow new lines in `::error::[message]` commands, but according to [this comment](https://github.com/actions/toolkit/issues/193#issuecomment-605394935), you can use `%0A` instead.