### PR TITLE
Fix Command Race Condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ var pipeline = builder.Build();
 
 await pipeline.RunAsync();
 ```
+
 ### Options
 
 You can configure the GitHub Actions runtime by providing options to the `AddGitHubActionsRuntime` method. The options allow you to customize the behavior of the runtime, such as the runtime detector and logging settings.s
@@ -57,3 +58,62 @@ The GitHub Actions integration includes a logging formatter that adapts the logg
 ### Commands
 
 With the GitHub Actions integration registered, you can inject the `IGitHubActionsCommands` interface into your pipeline steps to run commands in the GitHub Actions environment, including manually writing logs, grouping log messages and setting outputs.
+
+#### Log Messages
+
+You can log messages directly to the GitHub Actions log using the `LogNotice`, `LogWarning` and `LogError` methods:
+
+```csharp
+public class MyPipelineStep(IGitHubActionsCommands gh) : IPipelineStep
+{
+    public Task Run(CancellationToken cancellationToken = new())
+    {
+        gh.LogError(
+            message: "This is an error message.",
+            title: "Notice",
+            file: "README.md",
+            startLine: 1,
+            endLine: 1,
+            startColumn: 1,
+            endColumn: 1
+        );
+        return Task.CompletedTask;
+    }
+}
+```
+
+#### Log Grouping
+
+Logs are grouped automatically by pipeline step. However, you can also create custom log groups using the `StartGroup` and `EndGroup` methods, or the `WithGroup` method. GitHub Actions logs don't support nested groups, so this functionality is mostly useful for creating groups outside of pipeline steps such as in hooks.
+
+```csharp
+public class MyPipelineStep(ILogger<MyPipelineStep> logger, GitHubActionsCommands gh) : IPipelineStep
+{
+    public Task Run(CancellationToken cancellationToken = new())
+    {
+        gh.BeginGroup("My Custom Group");
+        logger.LogInformation("This log is inside the custom group.");
+        gh.EndGroup();
+
+        using (gh.WithGroup("My Other Custom Group"))
+        {
+            logger.LogInformation("This log is inside the other custom group.");
+        }
+        return Task.CompletedTask;
+    }
+}
+```
+
+#### Job Summaries
+
+GitHub Actions supports job summaries that are displayed in the UI after a job completes. You can append content to the job summary using the `AppendJobSummary` method. Internally, this writes to a file specified by the `GITHUB_STEP_SUMMARY` environment variable, so you can call this method multiple times to append content.
+
+```csharp
+public class MyPipelineStep(ILogger<MyPipelineStep> logger, GitHubActionsCommands gh) : IPipelineStep
+{
+    public async Task Run(CancellationToken cancellationToken = new())
+    {
+        await gh.AppendJobSummary("# Job Summary\nThis is the summary of the job.");
+    }
+}
+```

--- a/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
@@ -7,7 +7,7 @@ namespace Hamelin.Runtimes.GitHubActions;
 /// <remarks>
 /// Based on https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
 /// </remarks>
-public class GitHubActionsCommands(ILogger<GitHubActionsCommands> logger) : IGitHubActionsCommands
+internal class GitHubActionsCommands(ILogger<GitHubActionsCommands> logger) : IGitHubActionsCommands
 {
     /// <inheritdoc />
     public void LogDebug(string message) => WriteCommand("debug", message, null);

--- a/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
@@ -58,7 +58,11 @@ public class GitHubActionsCommands(ILogger<GitHubActionsCommands> logger) : IGit
     }
 
     /// <inheritdoc />
-    public IDisposable WithGroup(string title) => new DisposableGroup(this);
+    public IDisposable WithGroup(string title)
+    {
+        BeginGroup(title);
+        return new DisposableGroup(this);
+    }
 
     /// <inheritdoc />
     public async Task AppendJobSummary(string summary, CancellationToken cancellationToken = default)

--- a/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
@@ -1,10 +1,13 @@
+using Hamelin.Runtimes.GitHubActions.Logging;
+using Microsoft.Extensions.Logging;
+
 namespace Hamelin.Runtimes.GitHubActions;
 
 /// <inheritdoc />
 /// <remarks>
 /// Based on https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
 /// </remarks>
-public class GitHubActionsCommands : IGitHubActionsCommands
+public class GitHubActionsCommands(ILogger<GitHubActionsCommands> logger) : IGitHubActionsCommands
 {
     /// <inheritdoc />
     public void LogDebug(string message) => WriteCommand("debug", message, null);
@@ -55,6 +58,9 @@ public class GitHubActionsCommands : IGitHubActionsCommands
     }
 
     /// <inheritdoc />
+    public IDisposable WithGroup(string title) => new DisposableGroup(this);
+
+    /// <inheritdoc />
     public async Task AppendJobSummary(string summary, CancellationToken cancellationToken = default)
     {
         // The discrepancy between "job summary" and "step summary" is as per GitHub's documentation.
@@ -65,10 +71,11 @@ public class GitHubActionsCommands : IGitHubActionsCommands
             throw new InvalidOperationException($"Environment variable '{envVarName}' is not set. " +
                                                 $"Ensure that you are running this in a GitHub Actions environment.");
         }
+
         await File.WriteAllTextAsync(path, summary, cancellationToken);
     }
 
-    private static void WriteFileCommand(
+    private void WriteFileCommand(
         string command,
         string message,
         string? title = null,
@@ -91,7 +98,7 @@ public class GitHubActionsCommands : IGitHubActionsCommands
         WriteCommand(command, message, args);
     }
 
-    private static void WriteCommand(string command, string message, Dictionary<string, string?>? args)
+    private void WriteCommand(string command, string message, Dictionary<string, string?>? args)
     {
         string argString = "";
         if (args != null)
@@ -107,6 +114,14 @@ public class GitHubActionsCommands : IGitHubActionsCommands
         }
 
         message = StringUtils.SanitizeNewLines(message);
-        Console.Out.WriteLine($"::{command}{argString}::{message}");
+        string commandText = $"::{command}{argString}::{message}";
+
+        // Use a special event ID so the formatter knows to output the command as-is.
+        logger.LogInformation(Constants.RawCommandEventId, "{Command}", commandText);
+    }
+
+    private class DisposableGroup(IGitHubActionsCommands commands) : IDisposable
+    {
+        public void Dispose() => commands.EndGroup();
     }
 }

--- a/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommands.cs
@@ -126,6 +126,12 @@ public class GitHubActionsCommands(ILogger<GitHubActionsCommands> logger) : IGit
 
     private class DisposableGroup(IGitHubActionsCommands commands) : IDisposable
     {
-        public void Dispose() => commands.EndGroup();
+        private bool _disposed;
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            commands.EndGroup();
+        }
     }
 }

--- a/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommandsStub.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/GitHubActionsCommandsStub.cs
@@ -19,6 +19,12 @@ internal class GitHubActionsCommandsStub : IGitHubActionsCommands
     public void BeginGroup(string title) { }
 
     public void EndGroup() { }
+    public IDisposable WithGroup(string title) => new NullDisposable();
 
     public Task AppendJobSummary(string summary, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    private class NullDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
 }

--- a/src/Hamelin.Runtimes.GitHubActions/Hamelin.Runtimes.GitHubActions.csproj
+++ b/src/Hamelin.Runtimes.GitHubActions/Hamelin.Runtimes.GitHubActions.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/hamelin-org/Hamelin.Runtimes.GitHubActions.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Hamelin.Runtimes.GitHubActions/Hamelin.Runtimes.GitHubActions.csproj
+++ b/src/Hamelin.Runtimes.GitHubActions/Hamelin.Runtimes.GitHubActions.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/hamelin-org/Hamelin.Runtimes.GitHubActions.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Hamelin.Runtimes.GitHubActions/IGitHubActionsCommands.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/IGitHubActionsCommands.cs
@@ -83,6 +83,13 @@ public interface IGitHubActionsCommands
     void EndGroup();
 
     /// <summary>
+    /// Starts an expandable group in the GitHub Actions log, which completes when the returned object is disposed.
+    /// </summary>
+    /// <param name="title">The title of the group.</param>
+    /// <returns>A disposable object that will complete the group.</returns>
+    IDisposable WithGroup(string title);
+
+    /// <summary>
     /// Writes content to the job summary for the GitHub Actions run.
     /// </summary>
     /// <param name="summary">The summary text to write. GitHub flavored Markdown is supported.</param>

--- a/src/Hamelin.Runtimes.GitHubActions/Logging/Constants.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/Logging/Constants.cs
@@ -1,6 +1,9 @@
+using Microsoft.Extensions.Logging;
+
 namespace Hamelin.Runtimes.GitHubActions.Logging;
 
 internal static class Constants
 {
     public const string FormatterName = "GitHubActions";
+    public static readonly EventId RawCommandEventId = new(0, "GitHubActionsRawCommand");
 }

--- a/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsConsoleFormatter.cs
+++ b/src/Hamelin.Runtimes.GitHubActions/Logging/GitHubActionsConsoleFormatter.cs
@@ -12,6 +12,16 @@ internal class GitHubActionsConsoleFormatter() : ConsoleFormatter(Constants.Form
         TextWriter textWriter
     )
     {
+        // Check if this is a raw GitHub Actions command
+        // Important to check this by NAME because EventId equality goes by the numeric Id.
+        if (logEntry.EventId.Name == Constants.RawCommandEventId.Name)
+        {
+            // Write the message directly without any formatting
+            string rawMessage = logEntry.Formatter.Invoke(logEntry.State, logEntry.Exception);
+            textWriter.WriteLine(rawMessage);
+            return;
+        }
+
         switch (logEntry.LogLevel)
         {
             case LogLevel.Critical:

--- a/tests/Hamelin.Runtimes.GitHubActions.Tests.Unit/GitHubActionsCommandsTests.cs
+++ b/tests/Hamelin.Runtimes.GitHubActions.Tests.Unit/GitHubActionsCommandsTests.cs
@@ -53,6 +53,7 @@ public class GitHubActionsCommandsTests
             startColumn: 3,
             endColumn: 4
         );
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();
@@ -66,6 +67,7 @@ public class GitHubActionsCommandsTests
 
         // Act
         _sut.LogNotice("This is a notice message");
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();
@@ -87,6 +89,7 @@ public class GitHubActionsCommandsTests
             startColumn: 3,
             endColumn: 4
         );
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();
@@ -100,6 +103,7 @@ public class GitHubActionsCommandsTests
 
         // Acts
         _sut.LogWarning("This is a warning message");
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();
@@ -121,6 +125,7 @@ public class GitHubActionsCommandsTests
             startColumn: 3,
             endColumn: 4
         );
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();
@@ -134,6 +139,7 @@ public class GitHubActionsCommandsTests
 
         // Acts
         _sut.LogError("This is an error message");
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();
@@ -147,6 +153,7 @@ public class GitHubActionsCommandsTests
 
         // Act
         _sut.BeginGroup("Title");
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();
@@ -160,6 +167,7 @@ public class GitHubActionsCommandsTests
 
         // Act
         _sut.EndGroup();
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();
@@ -186,5 +194,36 @@ public class GitHubActionsCommandsTests
         {
             File.Delete(tempFile);
         }
+    }
+
+    [Fact]
+    public void WithGroup_DisposesCorrectly_LogsBothGroupAndEndGroup()
+    {
+        // Arrange
+        var group = _sut.WithGroup("Test Group");
+
+        // Act
+        group.Dispose();
+        _loggerFactory.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldBe("::group::Test Group\n::endgroup::\n");
+    }
+
+    [Fact]
+    public void WithGroup_MultipleDisposeCalls_OnlyLogsOnce()
+    {
+        // Arrange
+        IDisposable group = _sut.WithGroup("Test Group");
+
+        // Act
+        group.Dispose();
+        group.Dispose();
+        _loggerFactory.Dispose();
+
+        // Assert
+        string output = _writer.ToString();
+        output.ShouldBe("::group::Test Group\n::endgroup::\n");
     }
 }

--- a/tests/Hamelin.Runtimes.GitHubActions.Tests.Unit/GitHubActionsCommandsTests.cs
+++ b/tests/Hamelin.Runtimes.GitHubActions.Tests.Unit/GitHubActionsCommandsTests.cs
@@ -1,4 +1,6 @@
-using System.Formats.Asn1;
+using Hamelin.Runtimes.GitHubActions.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 
 namespace Hamelin.Runtimes.GitHubActions.Tests.Unit;
 
@@ -6,11 +8,20 @@ namespace Hamelin.Runtimes.GitHubActions.Tests.Unit;
 public class GitHubActionsCommandsTests
 {
     private readonly StringWriter _writer = new();
-    private readonly GitHubActionsCommands _sut = new();
+    private readonly ILoggerFactory _loggerFactory;
+
+    private readonly GitHubActionsCommands _sut;
 
     public GitHubActionsCommandsTests()
     {
         Console.SetOut(_writer);
+
+        _loggerFactory = LoggerFactory.Create(b => b
+            .AddConsole(o => o.FormatterName = Constants.FormatterName)
+            .AddConsoleFormatter<GitHubActionsConsoleFormatter, ConsoleFormatterOptions>()
+        );
+        var logger = _loggerFactory.CreateLogger<GitHubActionsCommands>();
+        _sut = new GitHubActionsCommands(logger);
     }
 
     [Fact]
@@ -20,6 +31,7 @@ public class GitHubActionsCommandsTests
 
         // Act
         _sut.LogDebug("This is a debug message");
+        _loggerFactory.Dispose();
 
         // Assert
         string output = _writer.ToString();


### PR DESCRIPTION
Because the `GitHubActionsCommands` class was writing directly to the console, it meant that messages were arriving in the logs out of order, because `ILogger` uses buffering.

This fixes the issue by updating the command runner to go through `ILogger` instead, using a well known `EventId` as a way to instruct the log formatter not to add its usual formatting.

Additionally, I added a new `WithGroup` method to the command runner that lets you dispose an object to close the group just to make using it a bit nicer.